### PR TITLE
Fix missing space in nginx config

### DIFF
--- a/18/nginx.ps1
+++ b/18/nginx.ps1
@@ -1,7 +1,7 @@
 configuration nginx {
     Import-DSCResource -Module nx
     Node localhost {
-        nxPackagenginx {
+        nxPackage nginx {
             Name ="nginx"
             Ensure = "Present"
             PackageManager = "apt"


### PR DESCRIPTION
Missing space between nxPackage and nginx on line 4 prevents configuration from compiling